### PR TITLE
Security Changes

### DIFF
--- a/backend/src/main/java/com/videolibrary/backend/configuration/SecurityConfig.java
+++ b/backend/src/main/java/com/videolibrary/backend/configuration/SecurityConfig.java
@@ -8,7 +8,13 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
-import org.springframework.security.oauth2.jwt.*;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtDecoder;
+import org.springframework.security.oauth2.jwt.JwtDecoders;
+import org.springframework.security.oauth2.jwt.JwtValidators;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.oauth2.server.resource.web.BearerTokenResolver;
+import org.springframework.security.oauth2.server.resource.web.DefaultBearerTokenResolver;
 import org.springframework.security.web.SecurityFilterChain;
 
 /**
@@ -44,6 +50,19 @@ public class SecurityConfig {
         });
 
         return http.build();
+    }
+
+    @Bean
+    BearerTokenResolver bearerTokenResolver() {
+        /*
+        Allow passing the authorization token as a query parameter in request URI. This is not recommended,
+        but it is the only way to make the native HTML5 video player work as it does not allow setting
+        custom request headers.
+         */
+
+        DefaultBearerTokenResolver bearerTokenResolver = new DefaultBearerTokenResolver();
+        bearerTokenResolver.setAllowUriQueryParameter(true);
+        return bearerTokenResolver;
     }
 
     @Bean

--- a/backend/src/main/java/com/videolibrary/backend/configuration/WebMvcConfig.java
+++ b/backend/src/main/java/com/videolibrary/backend/configuration/WebMvcConfig.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.HandlerInterceptor;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -16,5 +17,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(interceptor);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**");
     }
 }

--- a/backend/src/main/java/com/videolibrary/backend/infrastructure/rest/controller/FileUploadController.java
+++ b/backend/src/main/java/com/videolibrary/backend/infrastructure/rest/controller/FileUploadController.java
@@ -4,15 +4,10 @@ import com.videolibrary.backend.infrastructure.service.FileResourceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.UUID;
@@ -27,7 +22,7 @@ public class FileUploadController {
     public ResponseEntity<Resource> serveFile(@PathVariable UUID id) {
         Resource file = storageService.loadAsResource(id);
         return ResponseEntity.ok()
-                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + file.getFilename() + "\"")
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_OCTET_STREAM_VALUE)
                 .body(file);
     }
 


### PR DESCRIPTION
- Enabled CORS globally
- Enabled auth token resolution from header (this is not recommended but it's the only way to make authenticated requests from native HTML video player and image tags)
- Set `Content-Type` header for files to `application/octet-stream` as without this the videos fail to play.